### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y install git scons ctags pkg-config protobuf-compiler libprotobuf-
 
 # build libsodium
 ADD https://download.libsodium.org/libsodium/releases/libsodium-0.6.0.tar.gz libsodium-0.6.0.tar.gz
-RUN tar zxf libsodium-0.6.0.tar.gz && cd libsodium-0.6.0 && ./configure && make && sudo make install
+RUN tar zxf libsodium-0.6.0.tar.gz && cd libsodium-0.6.0 && ./configure && make && make install
 
 # build stellard
 ADD . /stellard-src


### PR DESCRIPTION
This adds a Dockerfile, which allows people to quickly get a working stellard container running on https://www.docker.com/.

My master branch is currently configured as an Automated Build at https://registry.hub.docker.com/u/oddbloke/stellard/, so you can test it by doing:

```
docker pull oddbloke/stellard:latest
docker run oddbloke/stellard:latest
```
