### PR TITLE
Explcitly include <string> to fix a bug when building with clang. Fixes #40.

### DIFF
--- a/src/ripple/types/api/Base58.h
+++ b/src/ripple/types/api/Base58.h
@@ -33,6 +33,7 @@
 #define RIPPLE_TYPES_BASE58_H
 
 #include <iterator>
+#include <string>
 #include <type_traits>
 
 #include "Blob.h"


### PR DESCRIPTION
Pretty easy fix. I can verify that this compiles on OS X 10.9.4 with clang 5.1.
