### PR TITLE
Fix hostname for public stellard

### DIFF
--- a/vagrant/stellard-public-ledger.cfg
+++ b/vagrant/stellard-public-ledger.cfg
@@ -59,7 +59,7 @@ full
 127.0.0.1
 
 [ips]
-public-01.stellar.org 52001
+live.stellar.org 52001
 
 # The latest validators can be obtained from
 # https://stellar.org/stellar.txt


### PR DESCRIPTION
Note also that the file references an `https://stellar.org/stellar.txt` which doesn't exist.
