### PR TITLE
Change default validator ips to use the gostellar.org domain.

### DIFF
--- a/doc/stellard-example.cfg
+++ b/doc/stellard-example.cfg
@@ -800,11 +800,11 @@ pool.ntp.org
 # Where to find some other servers speaking the Stellar protocol.
 #
 [ips]
-validator-01.stellar.org 52001
-validator-02.stellar.org 52001
-validator-03.stellar.org 52001
-validator-04.stellar.org 52001
-validator-05.stellar.org 52001
+validator-01.gostellar.org 52001
+validator-02.gostellar.org 52001
+validator-03.gostellar.org 52001
+validator-04.gostellar.org 52001
+validator-05.gostellar.org 52001
 
 # The latest validators can be obtained from
 # https://stellar.org/stellar.txt


### PR DESCRIPTION
The validator addresses do not work with stellar.org (at least when I checked as of now). Using this cfg file verbatim means that stellard cannot connect to any peers. Changing them to gostellar.org solves the issue.
