### PR TITLE
Moved default peer port 51235 -> 52001

### DIFF
--- a/doc/stellard-example.cfg
+++ b/doc/stellard-example.cfg
@@ -739,7 +739,7 @@
 0.0.0.0
 
 [peer_port]
-51235
+52001
 
 # Allow untrusted clients to connect to this server.
 #


### PR DESCRIPTION
The official validators use port 52001. This makes the example cfg file use this port too.
