### PR TITLE
Wrap references to htonll/ntohll to avoid macro expansion in Yosemite.

### DIFF
--- a/src/websocket/src/network_utilities.cpp
+++ b/src/websocket/src/network_utilities.cpp
@@ -29,7 +29,7 @@
 
 
 
-uint64_t zsutil::htonll(uint64_t src) { 
+uint64_t (zsutil::htonll)(uint64_t src) { 
     static int typ = TYP_INIT; 
     unsigned char c; 
     union { 
@@ -50,8 +50,8 @@ uint64_t zsutil::htonll(uint64_t src) {
     return x.ull; 
 }
 
-uint64_t zsutil::ntohll(uint64_t src) { 
-    return htonll(src);
+uint64_t (zsutil::ntohll)(uint64_t src) { 
+    return (htonll)(src);
 }
 
 std::string zsutil::lookup_ws_close_status_string(uint16_t code) {

--- a/src/websocket/src/network_utilities.hpp
+++ b/src/websocket/src/network_utilities.hpp
@@ -41,8 +41,8 @@ namespace zsutil {
 #define TYP_SMLE 1 
 #define TYP_BIGE 2 
 
-uint64_t htonll(uint64_t src);
-uint64_t ntohll(uint64_t src);
+uint64_t (htonll)(uint64_t src);
+uint64_t (ntohll)(uint64_t src);
 
 std::string lookup_ws_close_status_string(uint16_t code);
 

--- a/src/websocket/src/processors/hybi_header.cpp
+++ b/src/websocket/src/processors/hybi_header.cpp
@@ -144,7 +144,7 @@ void hybi_header::set_payload_size(uint64_t size) {
             m_header[1] |= BASIC_PAYLOAD_64BIT_CODE;
         }
         m_payload_size = size;
-        *(reinterpret_cast<uint64_t*>(&m_header[BASIC_HEADER_LENGTH])) = zsutil::htonll(size);
+        *(reinterpret_cast<uint64_t*>(&m_header[BASIC_HEADER_LENGTH])) = (zsutil::htonll)(size);
     } else {
         throw processor::exception("set_payload_size called with value that was too large (>2^63)",processor::error::MESSAGE_TOO_BIG);
     }
@@ -265,7 +265,7 @@ void hybi_header::process_extended_header() {
     } else if (s == BASIC_PAYLOAD_64BIT_CODE) {
         // reinterpret the second eight bytes as a 64 bit integer in 
         // network byte order. Convert to host byte order and store.
-        m_payload_size = zsutil::ntohll(*(
+        m_payload_size = (zsutil::ntohll)(*(
             reinterpret_cast<uint64_t*>(&m_header[BASIC_HEADER_LENGTH])
         ));
         

--- a/src/websocket/src/websocket_frame.hpp
+++ b/src/websocket/src/websocket_frame.hpp
@@ -398,7 +398,7 @@ public:
             *reinterpret_cast<uint16_t*>(&m_header[BASIC_HEADER_LENGTH]) = htons(s);
         } else if (s <= limits::PAYLOAD_SIZE_JUMBO) {
             m_header[1] = BASIC_PAYLOAD_64BIT_CODE;
-            *reinterpret_cast<uint64_t*>(&m_header[BASIC_HEADER_LENGTH]) = zsutil::htonll(s);
+            *reinterpret_cast<uint64_t*>(&m_header[BASIC_HEADER_LENGTH]) = (zsutil::htonll)(s);
         } else {
             throw processor::exception("payload size limit is 63 bits",processor::error::PROTOCOL_VIOLATION);
         }
@@ -499,7 +499,7 @@ public:
         } else if (s == BASIC_PAYLOAD_64BIT_CODE) {
             // reinterpret the second eight bytes as a 64 bit integer in 
             // network byte order. Convert to host byte order and store.
-            payload_size = zsutil::ntohll(*(
+            payload_size = (zsutil::ntohll)(*(
                 reinterpret_cast<uint64_t*>(&m_header[BASIC_HEADER_LENGTH])
             ));
             


### PR DESCRIPTION
Yosemite declares macros for htonll/ntohll in sys/_endian.h that break the build. Wrapping the function names stops macro expansion.
