### PR TITLE
Use C++ mode for .h files in emacs.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -9,5 +9,6 @@
                                          "src/snappy/snappy"
                                          "src/snappy/config"
                                          ))
+         (eval . (add-to-list 'auto-mode-alist '("\\.h\\'" . c++-mode)))
          (c-file-style . "stroustrup")
          (compile-command . "scons ccache=1 -D -j $(nproc)"))))


### PR DESCRIPTION
This just switches emacs to use C++ mode when editing .h files, rather than C mode. It is motivated by the fact that flycheck runs clang in C mode (not C++ mode) to check the syntax and semantics of the file while editing, and clang complains.
