### PR TITLE
Fix minor OSX build issue in LedgerDump.cpp

### DIFF
--- a/src/ripple_app/main/LedgerDump.cpp
+++ b/src/ripple_app/main/LedgerDump.cpp
@@ -267,7 +267,7 @@ void
 LedgerDump::loadTransactions (std::string const& filename)
 {
     std::ifstream in (filename);
-    require (in, "opening file");
+    require (in.good(), "opening file");
 
     std::unique_ptr <Application> app (make_Application ());
     app->setup ();


### PR DESCRIPTION
Coercion of istream to bool doesn't work in some versions of clang++.
