### PR TITLE
Revert "Serve broken history chains if we have them."

### DIFF
--- a/src/ripple_app/ledger/LedgerMaster.cpp
+++ b/src/ripple_app/ledger/LedgerMaster.cpp
@@ -18,7 +18,6 @@
 //==============================================================================
 
 #include <cassert>
-#include <boost/range/adaptor/reversed.hpp>
 
 namespace ripple {
 
@@ -466,34 +465,55 @@ public:
         return e;
     }
 
-    /**
-     * Starting from `ledger`, scan in decreasing order through batches of ledgers held in the SQL
-     * database filling in the RangeSet `mCompleteLedgers`.
-     *
-     * Stop when there are no more ledgers, or at the first ledger sequence number already held in
-     * `mCompleteLedgers`.
-     *
-     * Previous version of this function stopped at the first break in the `prevHash` chain, but we
-     * are (for the time being) willing to serve ledgers even from a broken history chain.
-     */
     void tryFill (Job& job, Ledger::pointer ledger)
     {
-        LedgerSeq batchSize = 500;
-        for (LedgerSeq high = ledger->getLedgerSeq (); high != 0; high -= std::min(high, batchSize))
+        std::uint32_t seq = ledger->getLedgerSeq ();
+        uint256 prevHash = ledger->getParentHash ();
+
+        std::map< std::uint32_t, std::pair<uint256, uint256> > ledgerHashes;
+
+        std::uint32_t minHas = ledger->getLedgerSeq ();
+        std::uint32_t maxHas = ledger->getLedgerSeq ();
+
+        while (! job.shouldCancel() && seq > 0)
         {
-            if (job.shouldCancel() || getApp().isShutdown ())
-                return;
-
-            LedgerSeq low = (high < batchSize) ? 0 : (high - (batchSize - 1));
-            auto const ledgerHashes = Ledger::getHashesByIndex (low, high);
-
-            ScopedLockType sl (mCompleteLock);
-            for (auto const &i : boost::adaptors::reverse(ledgerHashes))
             {
-                if (mCompleteLedgers.hasValue (i.first))
+                ScopedLockType ml (m_mutex);
+                minHas = seq;
+                --seq;
+
+                if (haveLedger (seq))
                     break;
-                mCompleteLedgers.setValue (i.first);
             }
+
+            std::map< std::uint32_t, std::pair<uint256, uint256> >::iterator it = ledgerHashes.find (seq);
+
+            if (it == ledgerHashes.end ())
+            {
+                if (getApp().isShutdown ())
+                    return;
+
+                {
+                    ScopedLockType ml (mCompleteLock);
+                    mCompleteLedgers.setRange (minHas, maxHas);
+                }
+                maxHas = minHas;
+                ledgerHashes = Ledger::getHashesByIndex ((seq < 500) ? 0 : (seq - 499), seq);
+                it = ledgerHashes.find (seq);
+
+                if (it == ledgerHashes.end ())
+                    break;
+            }
+
+            if (it->second.first != prevHash)
+                break;
+
+            prevHash = it->second.second;
+        }
+
+        {
+            ScopedLockType ml (mCompleteLock);
+            mCompleteLedgers.setRange (minHas, maxHas);
         }
         {
             ScopedLockType ml (m_mutex);


### PR DESCRIPTION
This reverts commit d448e541c0b7ff1715a8749e34542f562508f848.

It might be contributing to accumulation of _new_ fragmentation in the validators, though I do not see any immediately apparent reason why it should be.
