### PR TITLE
fix refactor bug to commit the entire transaction

### DIFF
--- a/src/ledger/LedgerMaster.cpp
+++ b/src/ledger/LedgerMaster.cpp
@@ -263,6 +263,8 @@ namespace stellar
                 WriteLog(ripple::lsINFO, ripple::Ledger) << "Imported " << totalImports << " items";
 
                 updateDBFromLedger(newLedger);
+
+                tx.endTransaction(true);
             }
             catch (...) {
                 WriteLog(ripple::lsWARNING, ripple::Ledger) << "Could not import state";


### PR DESCRIPTION
bug introduced with latest refactor around "TransactionScopeGuard":
last batch of transaction was rolled back by accident
