### PR TITLE
Changed build info to also include hash of source used to build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,8 @@ LICENSE binary
 *.vcxproj   text eol=crlf
 *.props     text eol=crlf
 *.filters   text eol=crlf
+
+# Enable version substitution on some files
+
+BuildInfo.cpp   ident
+

--- a/src/ripple/common/jsonrpc_fields.h
+++ b/src/ripple/common/jsonrpc_fields.h
@@ -70,6 +70,7 @@ JSS ( engine_result_code );
 JSS ( engine_result_message );
 JSS ( error );
 JSS ( error_exception );
+JSS ( extended_build_version );
 JSS ( fee_base );
 JSS ( fee_ref );
 JSS ( fetch_pack );

--- a/src/ripple_app/main/Main.cpp
+++ b/src/ripple_app/main/Main.cpp
@@ -251,8 +251,8 @@ int run (int argc, char** argv)
 
     if (vm.count ("version"))
     {
-        beast::String const& s (BuildInfo::getVersionString ());
-        std::cout << "rippled version " << s.toStdString() << std::endl;
+        beast::String const& s (BuildInfo::getFullVersionString ());
+        std::cout << "stellard version " << s.toStdString() << std::endl;
         return 0;
     }
 

--- a/src/ripple_app/misc/NetworkOPs.cpp
+++ b/src/ripple_app/misc/NetworkOPs.cpp
@@ -1704,6 +1704,8 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
 
     info [jss::build_version] = BuildInfo::getVersionString ();
 
+    info [jss::extended_build_version] = BuildInfo::getFullVersionString ();
+
     info [jss::server_state] = strOperatingMode ();
 
     if (mNeedNetworkLedger)

--- a/src/ripple_data/protocol/BuildInfo.cpp
+++ b/src/ripple_data/protocol/BuildInfo.cpp
@@ -119,8 +119,16 @@ char const* BuildInfo::getFullVersionString ()
         PrettyPrinter ()
         {
             beast::String s;
-            
+
+            std::string verHash = "$Id$"; // git substitutes this with hash of last commit
+
+            verHash = verHash.substr(5, 7);
+
             s << "Stellar-" << getVersionString ();
+            if (!verHash.empty())
+            {
+                s << " (" << verHash << ")";
+            }
 
             fullVersionString = s.toStdString ();
         }
@@ -231,7 +239,7 @@ public:
         testValues ();
 
         log <<
-            "  Ripple version: " <<
+            "  Stellar version: " <<
             BuildInfo::getVersionString();
     }
 };


### PR DESCRIPTION
This allows to quickly detect mismatches between builds where the build number was not manually updated
