### PR TITLE
Changed build info to also include hash of source used to build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -10,6 +10,7 @@ import platform
 import re
 import sys
 import textwrap
+import subprocess
 
 OSX = bool(platform.mac_ver()[0])
 FreeBSD = bool('FreeBSD' == platform.system())
@@ -568,6 +569,16 @@ def build_test(env,path):
         env_.Append(LIBS = libs)
     env_.Program (bin, srcs)
 
+# generates an include file with the hash of the latest commit
+def generate_build_signature():
+    cmd = ['git', 'describe', '--always', '--dirty']
+    entry = subprocess.check_output(cmd).decode('ascii').strip(" \t\r\n")
+    if len(entry) <= 3:
+        entry = "0" * 7
+    f = open('src/BuildSignature.h', 'w')
+    print >> f, '#define BUILD_SIGNATURE "%s"' % entry
+    f.close()
+
 #-------------------------------------------------------------------------------
 
 def main():
@@ -597,6 +608,8 @@ def main():
         '-frtti',
         '-g'
         ])
+
+    generate_build_signature()
 
     for root, dirs, files in os.walk('src/ripple'):
         for path in files:

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,6 @@
 # boost subtree
 /boost
+
+#generated automatically
+
+BuildSignature.h

--- a/src/ripple/common/jsonrpc_fields.h
+++ b/src/ripple/common/jsonrpc_fields.h
@@ -70,6 +70,7 @@ JSS ( engine_result_code );
 JSS ( engine_result_message );
 JSS ( error );
 JSS ( error_exception );
+JSS ( extended_build_version );
 JSS ( fee_base );
 JSS ( fee_ref );
 JSS ( fetch_pack );

--- a/src/ripple_app/main/Application.cpp
+++ b/src/ripple_app/main/Application.cpp
@@ -693,6 +693,8 @@ public:
             LogPartition::setConsoleOutput (getConfig().CONSOLE_LOG_OUTPUT);
         }
 
+        Log (lsWARNING) << "Starting up stellard version " << BuildInfo::getFullVersionString ();
+
         if (!getConfig ().RUN_STANDALONE)
             m_sntpClient->init (getConfig ().SNTP_SERVERS);
 

--- a/src/ripple_app/main/Main.cpp
+++ b/src/ripple_app/main/Main.cpp
@@ -251,8 +251,8 @@ int run (int argc, char** argv)
 
     if (vm.count ("version"))
     {
-        beast::String const& s (BuildInfo::getVersionString ());
-        std::cout << "rippled version " << s.toStdString() << std::endl;
+        beast::String const& s (BuildInfo::getFullVersionString ());
+        std::cout << "stellard version " << s.toStdString() << std::endl;
         return 0;
     }
 

--- a/src/ripple_app/misc/NetworkOPs.cpp
+++ b/src/ripple_app/misc/NetworkOPs.cpp
@@ -1704,6 +1704,8 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
 
     info [jss::build_version] = BuildInfo::getVersionString ();
 
+    info [jss::extended_build_version] = BuildInfo::getFullVersionString ();
+
     info [jss::server_state] = strOperatingMode ();
 
     if (mNeedNetworkLedger)

--- a/src/ripple_data/protocol/BuildInfo.cpp
+++ b/src/ripple_data/protocol/BuildInfo.cpp
@@ -25,6 +25,8 @@
 #include "beast/modules/beast_core/diagnostic/SemanticVersion.h"
 #include "BuildInfo.h"
 
+#include "../../BuildSignature.h"
+
 namespace ripple {
 
 char const* BuildInfo::getRawVersionString ()
@@ -119,8 +121,13 @@ char const* BuildInfo::getFullVersionString ()
         PrettyPrinter ()
         {
             beast::String s;
-            
+
+            std::string buildSignature(BUILD_SIGNATURE);
             s << "Stellar-" << getVersionString ();
+            if (!buildSignature.empty())
+            {
+                s << " (" << buildSignature << ")";
+            }
 
             fullVersionString = s.toStdString ();
         }
@@ -231,7 +238,7 @@ public:
         testValues ();
 
         log <<
-            "  Ripple version: " <<
+            "  Stellar version: " <<
             BuildInfo::getVersionString();
     }
 };


### PR DESCRIPTION
This allows to quickly detect mismatches between builds where the build number was not manually updated
