### PR TITLE
Add salvage_transactions command

### DIFF
--- a/src/ripple_app/main/LedgerDump.h
+++ b/src/ripple_app/main/LedgerDump.h
@@ -47,5 +47,6 @@ namespace ripple
         static void dumpLedger (int ledgerNum);
         static void dumpTransactions (std::string const& filename);
         static void loadTransactions (std::string const& filename);
+        static void salvageTransactions (int ledgerStart, int ledgerCount);
     };
 }


### PR DESCRIPTION
This is a lower-level dump command that does not attempt top-down instantiation of ledgers while dumping, but instead emits every transaction it can find in the database.
