### PR TITLE
Update build doc to require boost 1.55

### DIFF
--- a/doc/building-stellard.md
+++ b/doc/building-stellard.md
@@ -9,7 +9,7 @@ all commands and their implications.
 
 stellard is built with a software construction tool named scons. The
 build process checks that key packages - OpenSSL and Boost - are
-up-to-date; you can also override compilation flag defaults, or set tags
+at the right versions; you can also override compilation flag defaults, or set tags
 to control aspects of the build like debug mode.
 
 See also:
@@ -26,7 +26,7 @@ boost
 -----
 -   <http://www.boost.org>
 
-The latest version of boost is typically required to build stellard. We
+Version 1.55 of boost is required to build stellard. We
 suggest a separate installation of boost just for stellard, following
 the build instructions for boost provided at <http://boost.org>.
 


### PR DESCRIPTION
Using boost >= 1.56.0 causes this error:

```
In file included from src/ripple_app/ledger/Ledger.h:33:0,
                from src/ripple_app/ledger/LedgerMaster.h:25,
                from src/ripple_overlay/impl/PeerImp.cpp:11:
src/ripple_app/tx/TransactionMeta.h: In member function 'bool ripple::TransactionMetaSet::hasDeliveredAmount() const':
src/ripple_app/tx/TransactionMeta.h:114:17: error: cannot convert 'const boost::optional<ripple::STAmount>' to 'bool' in return
         return mDelivered;
                ^
scons: *** [build/obj/src/ripple_overlay/impl/PeerImp.o] Error 1
scons: building terminated because of errors.
```

Given feedback from @syrenity and cross-checked in the commit history from http://savannah.gnu.org/bugs/?43198:

> A breaking change was introduced in boost 1.56 [1]: the implicit
> conversion to bool was removed. Instead, an explicit operator
> bool was provided. The getters were also changed, so we cannot
> use them and retain compatibility with older boost versions.
> 
> By putting the would-be boolean expression in a conditional, we
> now invoke the explicit operator bool (also known as contextual
> conversion to bool) for boost >= 1.56 and the implicit conversion
> to bool for < 1.56.
